### PR TITLE
Add networking layer

### DIFF
--- a/app/src/main/java/com/gnb_android/commons/data/datasource/response/ApiResponse.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/response/ApiResponse.kt
@@ -1,0 +1,12 @@
+package com.gnb_android.commons.data.datasource.response
+
+/**
+ * This is a common class used by API responses
+ */
+sealed class ApiResponse<out Data>
+
+data class SuccessApiResponse<out Data>(val body: Data) : ApiResponse<Data>()
+
+object EmptyApiResponse : ApiResponse<Nothing>()
+
+object BusinessErrorApiResponse : ApiResponse<Nothing>()

--- a/app/src/main/java/com/gnb_android/commons/data/datasource/response/extensions/ResponseExtension.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/response/extensions/ResponseExtension.kt
@@ -1,0 +1,27 @@
+package com.gnb_android.commons.data.datasource.response.extensions
+
+
+import com.gnb_android.commons.data.datasource.response.*
+import retrofit2.Response
+
+/**
+ * Convert a Retrofit response into an ApiResponse to allow states management
+ */
+fun <Data> Response<Data>.mapToApiResponse(): ApiResponse<Data> {
+    return if (this.isSuccessful) {
+        when (this.code()) {
+            200 -> {
+                this.body()?.let { data ->
+                    SuccessApiResponse(data)
+                } ?: run {
+                    EmptyApiResponse
+                }
+            }
+            else -> {
+                EmptyApiResponse
+            }
+        }
+    } else {
+        BusinessErrorApiResponse
+    }
+}


### PR DESCRIPTION
### En este PR

- Se agrega la capa de networking
- Se agrega la "sealed class ApiResponse" y sus correspondientes para manejar los casos de éxito o error.
- Se agrega en commons la función mapToApiResponse para hacer manejo de las respuestas de los servicios que se consulten.