### PR TITLE
Add Transaction networking layer

### DIFF
--- a/app/src/main/java/com/gnb_android/home/data/datasource/transactions/ITransactionsDataSource.kt
+++ b/app/src/main/java/com/gnb_android/home/data/datasource/transactions/ITransactionsDataSource.kt
@@ -1,0 +1,9 @@
+package com.gnb_android.home.data.datasource.transactions
+
+import com.gnb_android.commons.data.datasource.response.ApiResponse
+import com.gnb_android.home.data.datasource.transactions.model.TransactionApiModel
+
+interface ITransactionsDataSource {
+
+    fun getTransactions(): ApiResponse<List<TransactionApiModel>>
+}

--- a/app/src/main/java/com/gnb_android/home/data/datasource/transactions/TransactionsRemoteDataSource.kt
+++ b/app/src/main/java/com/gnb_android/home/data/datasource/transactions/TransactionsRemoteDataSource.kt
@@ -1,0 +1,20 @@
+package com.gnb_android.home.data.datasource.transactions
+
+import com.gnb_android.commons.data.datasource.response.ApiResponse
+import com.gnb_android.commons.data.datasource.response.extensions.mapToApiResponse
+import com.gnb_android.home.data.datasource.transactions.api.TransactionsApi
+import com.gnb_android.home.data.datasource.transactions.model.TransactionApiModel
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class TransactionsRemoteDataSource(): ITransactionsDataSource {
+
+    private val BASE_URL = ""
+    private val api: TransactionsApi = Retrofit.Builder().baseUrl(BASE_URL)
+        .addConverterFactory(GsonConverterFactory.create()).build()
+        .create(TransactionsApi::class.java)
+
+    override fun getTransactions(): ApiResponse<List<TransactionApiModel>> {
+        return api.getTransactions().mapToApiResponse()
+    }
+}

--- a/app/src/main/java/com/gnb_android/home/data/datasource/transactions/api/TransactionsApi.kt
+++ b/app/src/main/java/com/gnb_android/home/data/datasource/transactions/api/TransactionsApi.kt
@@ -1,0 +1,12 @@
+package com.gnb_android.home.data.datasource.transactions.api
+
+import com.gnb_android.home.data.datasource.transactions.model.TransactionApiModel
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface TransactionsApi {
+
+    @GET("transactions")
+    fun getTransactions(): Response<List<TransactionApiModel>>
+
+}

--- a/app/src/main/java/com/gnb_android/home/data/datasource/transactions/model/TransactionsApiModel.kt
+++ b/app/src/main/java/com/gnb_android/home/data/datasource/transactions/model/TransactionsApiModel.kt
@@ -1,0 +1,10 @@
+package com.gnb_android.home.data.datasource.transactions.model
+
+import com.gnb_android.commons.data.datasource.currency.model.CurrencyTypeApiModel
+import java.math.BigDecimal
+
+data class TransactionApiModel(
+    val sku: String,
+    val amount: BigDecimal,
+    val currency: CurrencyTypeApiModel
+)

--- a/app/src/main/java/com/gnb_android/home/data/repository/transactions/TransactionsRepository.kt
+++ b/app/src/main/java/com/gnb_android/home/data/repository/transactions/TransactionsRepository.kt
@@ -1,0 +1,18 @@
+package com.gnb_android.home.data.repository.transactions
+
+import com.gnb_android.commons.data.repository.states.DataState
+import com.gnb_android.commons.data.repository.states.extensions.mapToDataState
+import com.gnb_android.home.data.datasource.transactions.ITransactionsDataSource
+import com.gnb_android.home.data.repository.transactions.extensions.convertToTransaction
+import com.gnb_android.home.data.repository.transactions.model.Transaction
+
+class TransactionsRepository(private val dataSource: ITransactionsDataSource) {
+
+    fun getTransactions(): DataState<List<Transaction>>  {
+        return dataSource.getTransactions().mapToDataState {
+            it.map { transactionApiModel ->
+                transactionApiModel.convertToTransaction()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gnb_android/home/data/repository/transactions/extensions/TransactionApiModelExtensions.kt
+++ b/app/src/main/java/com/gnb_android/home/data/repository/transactions/extensions/TransactionApiModelExtensions.kt
@@ -1,0 +1,28 @@
+package com.gnb_android.home.data.repository.transactions.extensions
+
+import com.gnb_android.commons.data.datasource.currency.model.CurrencyTypeApiModel
+import com.gnb_android.commons.data.repository.currency.model.CurrencyType
+import com.gnb_android.home.data.datasource.transactions.model.TransactionApiModel
+import com.gnb_android.home.data.repository.transactions.model.Transaction
+
+fun TransactionApiModel.convertToTransaction(): Transaction =
+    Transaction(
+        sku = sku,
+        amount = amount,
+        currency = currency.convertToCurrencyType()
+    )
+
+// Todo: Delete this function. It must be in a file of CurrencyExtensions
+fun CurrencyTypeApiModel.convertToCurrencyType(): CurrencyType {
+    return when (this) {
+        CurrencyTypeApiModel.EUR -> CurrencyType.EUR
+        CurrencyTypeApiModel.USD -> CurrencyType.USD
+        CurrencyTypeApiModel.CAD -> CurrencyType.CAD
+        CurrencyTypeApiModel.GBP -> CurrencyType.GBP
+        CurrencyTypeApiModel.JPY -> CurrencyType.JPY
+        CurrencyTypeApiModel.AUD -> CurrencyType.AUD
+        CurrencyTypeApiModel.SEK -> CurrencyType.SEK
+        CurrencyTypeApiModel.RUB -> CurrencyType.RUB
+        CurrencyTypeApiModel.INR -> CurrencyType.INR
+    }
+}

--- a/app/src/main/java/com/gnb_android/home/data/repository/transactions/model/Transaction.kt
+++ b/app/src/main/java/com/gnb_android/home/data/repository/transactions/model/Transaction.kt
@@ -1,0 +1,10 @@
+package com.gnb_android.home.data.repository.transactions.model
+
+import com.gnb_android.commons.data.repository.currency.model.CurrencyType
+import java.math.BigDecimal
+
+data class Transaction (
+    val sku: String,
+    val amount: BigDecimal,
+    val currency: CurrencyType
+)


### PR DESCRIPTION
### En este PR

- Se agrega el model TransactionApiModel
- Se agregan las funciones de extensión para transformar TransactionApiModel -> Transaction
- Se agrega ITransactionDataSource y TransactionRemoteDataSource
- Se agrega TransactionRepository