### PR TITLE
Add HomeScreen Ui

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -12,9 +14,8 @@
         android:theme="@style/Theme.Gnbandroid"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".home.ui.view.MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Gnbandroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/gnb_android/commons/ui/view/components/divider/GnbDivider.kt
+++ b/app/src/main/java/com/gnb_android/commons/ui/view/components/divider/GnbDivider.kt
@@ -1,0 +1,22 @@
+package com.gnb_android.commons.ui.view.components.divider
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * This divider is going to be used as separator for list items.
+ */
+@Composable
+fun GnbDivider(modifier: Modifier = Modifier) {
+    Divider(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        color = Color.Gray
+    )
+}

--- a/app/src/main/java/com/gnb_android/commons/ui/view/components/header/GnbHeader.kt
+++ b/app/src/main/java/com/gnb_android/commons/ui/view/components/header/GnbHeader.kt
@@ -1,0 +1,39 @@
+package com.gnb_android.commons.ui.view.components.header
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gnb_android.R
+
+
+@Composable
+fun GnbHeader(
+    @StringRes text: Int
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            text = stringResource(id = text)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun GnbHeaderPreview() {
+    GnbHeader(text = R.string.home_header_text)
+}

--- a/app/src/main/java/com/gnb_android/home/ui/view/HomeScreen.kt
+++ b/app/src/main/java/com/gnb_android/home/ui/view/HomeScreen.kt
@@ -1,0 +1,41 @@
+package com.gnb_android.home.ui.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gnb_android.R
+import com.gnb_android.commons.ui.view.components.header.GnbHeader
+
+@Composable
+fun HomeScreen() {
+    Scaffold(
+        topBar = {
+            GnbHeader(text = R.string.home_header_text)
+        },
+        content = { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .padding(horizontal = 16.dp)
+            ) {
+                Text(text = stringResource(id = R.string.home_screen_content_subtitle))
+                LazyColumn {
+                    // Todo: Add list of selectable items code
+                }
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun HomeScreenPreview() {
+    HomeScreen()
+}

--- a/app/src/main/java/com/gnb_android/home/ui/view/MainActivity.kt
+++ b/app/src/main/java/com/gnb_android/home/ui/view/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.gnb_android
+package com.gnb_android.home.ui.view
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/gnb_android/home/ui/view/components/TransactionDetailItem.kt
+++ b/app/src/main/java/com/gnb_android/home/ui/view/components/TransactionDetailItem.kt
@@ -1,0 +1,72 @@
+package com.gnb_android.home.ui.view.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gnb_android.R
+import com.gnb_android.commons.data.repository.currency.model.CurrencyType
+import com.gnb_android.commons.ui.view.components.divider.GnbDivider
+
+@Composable
+fun TransactionDetailItem(
+    code: String,
+    amount: String,
+    currency: CurrencyType,
+    isLastItem: Boolean = false
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .weight(0.2f),
+                text = stringResource(id = R.string.transaction_detail_item_title)
+            )
+            Text(
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .weight(0.4f),
+                text = code
+            )
+            Text(
+                modifier = Modifier
+                    .weight(0.3f)
+                    .padding(end = 4.dp),
+                textAlign = TextAlign.End,
+                text = stringResource(id = R.string.transaction_detail_item_amount, amount)
+            )
+            Text(
+                modifier = Modifier.weight(0.1f),
+                text = currency.name
+            )
+        }
+        if (!isLastItem) {
+            GnbDivider()
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TransactionDetailItemPreview() {
+    TransactionDetailItem(
+        code = "T2006",
+        amount = "34.57",
+        currency = CurrencyType.USD
+    )
+}

--- a/app/src/main/java/com/gnb_android/home/ui/view/components/TransactionTitleItem.kt
+++ b/app/src/main/java/com/gnb_android/home/ui/view/components/TransactionTitleItem.kt
@@ -1,0 +1,47 @@
+package com.gnb_android.home.ui.view.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gnb_android.commons.ui.view.components.divider.GnbDivider
+
+@Composable
+fun TransactionTitleItem(
+    text: String,
+    onClick: () -> Unit,
+    isLastItem: Boolean = false
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier.height(64.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                modifier = Modifier,
+                text = text
+            )
+        }
+        if (!isLastItem) {
+            GnbDivider()
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TransactionTitleItemPreview() {
+    TransactionTitleItem(text = "T2006", onClick = {})
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,11 @@
 <resources>
     <string name="app_name">gnb-android</string>
+
+    <!-- Home screen -->
+    <string name="home_header_text">Goliath National Bank</string>
+    <string name="home_screen_content_subtitle">Select an item:</string>
+
+    <!-- Transaction detail item -->
+    <string name="transaction_detail_item_title">Item code:</string>
+    <string name="transaction_detail_item_amount">$%1$s</string>
 </resources>


### PR DESCRIPTION
### En este PR

- Se agrega HomeScreen
- Se agregan componentes visuales para listar en pantalla (items para seleccionar por código, ítems para ver el detalle de las transacciones)
- Se agrega un divisor para usar en las listas que se muestren en la app