### PR TITLE
Migrate from Gson to Moshi

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,8 +64,10 @@ dependencies {
 
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation 'com.squareup.okhttp3:okhttp-tls:4.9.3'
+
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/gnb_android/commons/data/datasource/currency/CurrencyRemoteDataSource.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/currency/CurrencyRemoteDataSource.kt
@@ -1,18 +1,16 @@
 package com.gnb_android.commons.data.datasource.currency
 
-import com.gnb_android.BuildConfig.BASE_URL
 import com.gnb_android.commons.data.datasource.currency.api.CurrencyApi
 import com.gnb_android.commons.data.datasource.currency.model.CurrencyConversionsApiModel
 import com.gnb_android.commons.data.datasource.response.ApiResponse
 import com.gnb_android.commons.data.datasource.response.extensions.mapToApiResponse
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
+import com.gnb_android.core.connectivity.RetrofitFactory
 
 class CurrencyRemoteDataSource() : ICurrencyDataSource {
 
-    private val api: CurrencyApi = Retrofit.Builder().baseUrl(BASE_URL)
-        .addConverterFactory(GsonConverterFactory.create()).build()
-        .create(CurrencyApi::class.java)
+    private val api: CurrencyApi by lazy {
+        RetrofitFactory.getRetrofitService(CurrencyApi::class.java)
+    }
 
     override suspend fun getCurrencyRates(): ApiResponse<CurrencyConversionsApiModel> {
         return api.getCurrencyRates().mapToApiResponse()

--- a/app/src/main/java/com/gnb_android/commons/data/datasource/currency/model/CurrencyConversionsApiModel.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/currency/model/CurrencyConversionsApiModel.kt
@@ -1,6 +1,6 @@
 package com.gnb_android.commons.data.datasource.currency.model
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 import java.math.BigDecimal
 
 data class CurrencyConversionsApiModel(
@@ -14,22 +14,30 @@ data class CurrencyConversionItemApiModel(
 )
 
 enum class CurrencyTypeApiModel {
-    @SerializedName("EUR")
+    @Json(name = "EUR")
     EUR,
-    @SerializedName("USD")
+
+    @Json(name = "USD")
     USD,
-    @SerializedName("CAD")
+
+    @Json(name = "CAD")
     CAD,
-    @SerializedName("GBP")
+
+    @Json(name = "GBP")
     GBP,
-    @SerializedName("JPY")
+
+    @Json(name = "JPY")
     JPY,
-    @SerializedName("AUD")
+
+    @Json(name = "AUD")
     AUD,
-    @SerializedName("SEK")
+
+    @Json(name = "SEK")
     SEK,
-    @SerializedName("RUB")
+
+    @Json(name = "RUB")
     RUB,
-    @SerializedName("INR")
+
+    @Json(name = "INR")
     INR
 }

--- a/app/src/main/java/com/gnb_android/commons/data/datasource/remote/OkHttpFactoryImpl.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/remote/OkHttpFactoryImpl.kt
@@ -1,0 +1,11 @@
+package com.gnb_android.commons.data.datasource.remote
+
+import com.gnb_android.core.connectivity.OkHttpFactory
+import okhttp3.OkHttpClient
+
+class OkHttpFactoryImpl(): OkHttpFactory() {
+
+    override fun makeOkHttpClient(): OkHttpClient {
+        return getOkHttpClientBuilder().build()
+    }
+}

--- a/app/src/main/java/com/gnb_android/commons/data/datasource/remote/RetrofitFactoryImpl.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/remote/RetrofitFactoryImpl.kt
@@ -1,0 +1,19 @@
+package com.gnb_android.commons.data.datasource.remote
+
+import com.gnb_android.commons.data.datasource.remote.adapters.MoshiAdapters
+import com.gnb_android.core.connectivity.OkHttpFactory
+import com.gnb_android.core.connectivity.RetrofitFactory
+import okhttp3.OkHttpClient
+
+class RetrofitFactoryImpl(
+    private val baseUrl: String,
+) : RetrofitFactory() {
+
+    private val okHttpFactory: OkHttpFactory = OkHttpFactoryImpl()
+    private val okHttpClient: OkHttpClient = okHttpFactory.makeOkHttpClient()
+
+    override fun init(
+    ) {
+        initRetrofit(baseUrl, MoshiAdapters.converterFactory, okHttpClient)
+    }
+}

--- a/app/src/main/java/com/gnb_android/commons/data/datasource/remote/adapters/BigDecimalAdapter.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/remote/adapters/BigDecimalAdapter.kt
@@ -1,0 +1,9 @@
+package com.gnb_android.commons.data.datasource.remote.adapters
+
+import com.squareup.moshi.FromJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @FromJson
+    fun fromJson(string: String) = BigDecimal(string)
+}

--- a/app/src/main/java/com/gnb_android/commons/data/datasource/remote/adapters/MoshiAdapters.kt
+++ b/app/src/main/java/com/gnb_android/commons/data/datasource/remote/adapters/MoshiAdapters.kt
@@ -1,0 +1,16 @@
+package com.gnb_android.commons.data.datasource.remote.adapters
+
+import com.squareup.moshi.Moshi
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+class MoshiAdapters {
+    companion object {
+        val converterFactory: MoshiConverterFactory by lazy {
+            MoshiConverterFactory.create(
+                Moshi.Builder()
+                    .add(BigDecimalAdapter())
+                    .build()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/gnb_android/core/connectivity/OkHttpFactory.kt
+++ b/app/src/main/java/com/gnb_android/core/connectivity/OkHttpFactory.kt
@@ -1,0 +1,24 @@
+package com.gnb_android.core.connectivity
+
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+
+abstract class OkHttpFactory {
+
+    private val connectTimeout = 20L
+    private val readTimeout = 20L
+    private val callTimeout = 35L
+    private val timeUnit = TimeUnit.SECONDS
+
+    protected fun getOkHttpClientBuilder() : OkHttpClient.Builder {
+        return OkHttpClient.Builder()
+            .callTimeout(callTimeout, timeUnit)
+            .connectTimeout(connectTimeout, timeUnit)
+            .readTimeout(readTimeout, timeUnit)
+    }
+
+    /**
+     * Used to customize an OkHttpClient, for example by adding interceptors by build type
+     */
+    abstract fun makeOkHttpClient(): OkHttpClient
+}

--- a/app/src/main/java/com/gnb_android/core/connectivity/RetrofitFactory.kt
+++ b/app/src/main/java/com/gnb_android/core/connectivity/RetrofitFactory.kt
@@ -1,0 +1,37 @@
+package com.gnb_android.core.connectivity
+
+import com.gnb_android.BuildConfig.BASE_URL
+import okhttp3.OkHttpClient
+import retrofit2.Converter
+import retrofit2.Retrofit
+
+abstract class RetrofitFactory {
+
+    companion object {
+        private lateinit var client: OkHttpClient
+        private lateinit var converterFactory: Converter.Factory
+        private lateinit var baseUrl: String
+
+        private val instance: Retrofit by lazy {
+            Retrofit.Builder()
+                .baseUrl(baseUrl)
+                .addConverterFactory(converterFactory)
+                .client(client)
+                .build()
+        }
+
+        fun initRetrofit(
+            baseUrl: String = BASE_URL,
+            converterFactory: Converter.Factory,
+            client: OkHttpClient
+        ) {
+            Companion.baseUrl = baseUrl
+            Companion.converterFactory = converterFactory
+            Companion.client = client
+        }
+
+        fun <T> getRetrofitService(service: Class<T>): T = instance.create(service)
+    }
+
+    abstract fun init()
+}

--- a/app/src/main/java/com/gnb_android/home/data/datasource/transactions/TransactionsRemoteDataSource.kt
+++ b/app/src/main/java/com/gnb_android/home/data/datasource/transactions/TransactionsRemoteDataSource.kt
@@ -1,18 +1,16 @@
 package com.gnb_android.home.data.datasource.transactions
 
-import com.gnb_android.BuildConfig.BASE_URL
 import com.gnb_android.commons.data.datasource.response.ApiResponse
 import com.gnb_android.commons.data.datasource.response.extensions.mapToApiResponse
+import com.gnb_android.core.connectivity.RetrofitFactory
 import com.gnb_android.home.data.datasource.transactions.api.TransactionsApi
 import com.gnb_android.home.data.datasource.transactions.model.TransactionApiModel
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 
 class TransactionsRemoteDataSource() : ITransactionsDataSource {
 
-    private val api: TransactionsApi = Retrofit.Builder().baseUrl(BASE_URL)
-        .addConverterFactory(GsonConverterFactory.create()).build()
-        .create(TransactionsApi::class.java)
+    private val api: TransactionsApi by lazy {
+        RetrofitFactory.getRetrofitService(TransactionsApi::class.java)
+    }
 
     override fun getTransactions(): ApiResponse<List<TransactionApiModel>> {
         return api.getTransactions().mapToApiResponse()


### PR DESCRIPTION
### En este PR

- Se migra a Moshi ya que es más performante que Gson
- Se agrega el manejo de OkHttp3 para configurar timeouts de servicio
- Se elimina Gson