### PR TITLE
Observe Transactions State in Home Screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,8 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation "androidx.compose.material:material:1.3.1"
-
+    implementation 'androidx.compose.runtime:runtime-livedata:1.3.3'
+    
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'

--- a/app/src/main/java/com/gnb_android/home/data/repository/transactions/TransactionsRepository.kt
+++ b/app/src/main/java/com/gnb_android/home/data/repository/transactions/TransactionsRepository.kt
@@ -23,6 +23,6 @@ class TransactionsRepository(private val dataSource: ITransactionsDataSource) {
         return transactionsBySku.map {
             TransactionsBySku(it.key, it.value.map { transactionApiModel ->
                 transactionApiModel.convertToTransaction() })
-        }
+        }.sortedBy { it.sku }
     }
 }

--- a/app/src/main/java/com/gnb_android/home/ui/view/HomeScreen.kt
+++ b/app/src/main/java/com/gnb_android/home/ui/view/HomeScreen.kt
@@ -1,20 +1,42 @@
 package com.gnb_android.home.ui.view
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gnb_android.R
+import com.gnb_android.commons.data.datasource.currency.CurrencyRemoteDataSource
+import com.gnb_android.commons.data.repository.currency.CurrencyRepository
 import com.gnb_android.commons.ui.view.components.header.GnbHeader
+import com.gnb_android.commons.ui.viewmodel.states.BusinessError
+import com.gnb_android.commons.ui.viewmodel.states.Empty
+import com.gnb_android.commons.ui.viewmodel.states.Loading
+import com.gnb_android.commons.ui.viewmodel.states.Success
+import com.gnb_android.home.data.datasource.transactions.TransactionsRemoteDataSource
+import com.gnb_android.home.data.repository.transactions.TransactionsRepository
+import com.gnb_android.home.data.repository.transactions.model.TransactionsBySku
+import com.gnb_android.home.ui.view.components.TransactionTitleItem
+import com.gnb_android.home.ui.viewmodel.HomeViewModel
 
 @Composable
-fun HomeScreen() {
+fun HomeScreen(
+    viewModel: HomeViewModel
+) {
+
+    val transactionsState = viewModel.transactionsObservable.observeAsState()
+
     Scaffold(
         topBar = {
             GnbHeader(text = R.string.home_header_text)
@@ -26,16 +48,53 @@ fun HomeScreen() {
                     .padding(horizontal = 16.dp)
             ) {
                 Text(text = stringResource(id = R.string.home_screen_content_subtitle))
-                LazyColumn {
-                    // Todo: Add list of selectable items code
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    when (val state = transactionsState.value) {
+                        is Loading -> {
+                            CircularProgressIndicator(modifier = Modifier.padding(32.dp))
+                        }
+                        Empty -> {
+                            Text(text = "Empty content")
+                        }
+                        is Success -> {
+                            val transactionsBySku: List<TransactionsBySku> = state.body
+                            LazyColumn {
+                                itemsIndexed(transactionsBySku) { index, item ->
+                                    TransactionTitleItem(
+                                        text = item.sku,
+                                        onClick = { /*TODO*/ },
+                                        isLastItem = (index == transactionsBySku.size - 1)
+                                    )
+                                }
+                            }
+                        }
+                        BusinessError -> {
+                            Text(text = "Business error content")
+                        }
+                        null -> {
+                            // Do nothing
+                        }
+                    }
                 }
             }
         }
     )
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.getTransactions()
+    }
 }
 
 @Preview
 @Composable
 fun HomeScreenPreview() {
-    HomeScreen()
+    HomeScreen(
+        HomeViewModel(
+            CurrencyRepository(CurrencyRemoteDataSource()),
+            TransactionsRepository(TransactionsRemoteDataSource())
+        )
+    )
 }

--- a/app/src/main/java/com/gnb_android/home/ui/view/MainActivity.kt
+++ b/app/src/main/java/com/gnb_android/home/ui/view/MainActivity.kt
@@ -10,9 +10,22 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.gnb_android.commons.data.datasource.currency.CurrencyRemoteDataSource
+import com.gnb_android.commons.data.repository.currency.CurrencyRepository
+import com.gnb_android.home.data.datasource.transactions.TransactionsRemoteDataSource
+import com.gnb_android.home.data.repository.transactions.TransactionsRepository
+import com.gnb_android.home.ui.viewmodel.HomeViewModel
 import com.gnb_android.ui.theme.GnbandroidTheme
 
 class MainActivity : ComponentActivity() {
+
+    val viewModel by lazy {
+        HomeViewModel(
+            CurrencyRepository(CurrencyRemoteDataSource()),
+            TransactionsRepository(TransactionsRemoteDataSource())
+        )
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -22,22 +35,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    Greeting("Android")
+                    HomeScreen(viewModel = viewModel)
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    GnbandroidTheme {
-        Greeting("Android")
     }
 }


### PR DESCRIPTION
## En este PR

- Se observa al liveData de transacciones para poder mostrar la respuesta exitosa con la lista de códigos en la pantalla principal
- Se agrega la dependencia de compose runtime para poder observar como estado al liveData
- Se agrega la implementación con el contenido de la pantalla principal
- Se actualiza MainActivity

